### PR TITLE
Enable model path CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Weibo Sentiment Analysis
+
+This repository provides scripts for training a BERT-based sentiment classifier and for making predictions on single Weibo comments.
+
+## Training
+
+Run the training script with default settings:
+
+```bash
+python train.py --model_name bert-base-chinese
+```
+
+The trained model and logs will be saved under `experiments/`.
+
+## Prediction
+
+After training finishes you can predict the emotion of a new comment with `predict.py`. Provide the path to the saved model directory using `--model_path`:
+
+```bash
+python predict.py --model_path experiments/your_experiment/model
+```
+
+If omitted, `--model_path` defaults to `./model`.
+
+You will be prompted to enter a comment and the predicted emotion will be printed.

--- a/predict.py
+++ b/predict.py
@@ -1,30 +1,40 @@
+import argparse
+import json
 import torch
 from transformers import BertTokenizer, BertForSequenceClassification
-import sys
-import json
-
-# Load model and tokenizer
-model_path = "./model"
-tokenizer = BertTokenizer.from_pretrained(model_path)
-model = BertForSequenceClassification.from_pretrained(model_path)
-model.eval()
 
 # Load label mapping
 with open("label_mapping.json", "r", encoding="utf-8") as f:
     label_map = json.load(f)
 id2label = {v: k for k, v in label_map.items()}
 
-# Predict function
-def predict(text):
+def predict(text, tokenizer, model):
     inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True, max_length=128)
     with torch.no_grad():
         outputs = model(**inputs)
     predicted_class = torch.argmax(outputs.logits, dim=1).item()
     return id2label[predicted_class]
 
-# Example usage
-if __name__ == "__main__":
+
+def main():
+    parser = argparse.ArgumentParser(description="Predict emotion for a Weibo comment")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="./model",
+        help="Path to the trained model directory",
+    )
+    args = parser.parse_args()
+
+    tokenizer = BertTokenizer.from_pretrained(args.model_path)
+    model = BertForSequenceClassification.from_pretrained(args.model_path)
+    model.eval()
+
     text = input("Enter a Weibo comment: ")
-    result = predict(text)
+    result = predict(text, tokenizer, model)
     print(f"Predicted emotion: {result}")
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- let `predict.py` accept a `--model_path` argument
- document usage in a new README

## Testing
- `python -m py_compile predict.py train.py prepare_data.py`


------
https://chatgpt.com/codex/tasks/task_e_687f918bb7008322b51687080afb021a